### PR TITLE
modified build command so that image will push properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ CMD ["/hello"]
 We can then build this and push it to the Docker registry:
 
 ```
-$ docker build -t hello .
+$ docker build -t DOCKERHUB_USERNAME/hello .
 $ docker images
 $ docker tag IMAGE_ID DOCKERHUB_USERNAME/hello:latest
 $ docker push DOCKERHUB_USERNAME/hello

--- a/README.md
+++ b/README.md
@@ -92,9 +92,7 @@ CMD ["/hello"]
 We can then build this and push it to the Docker registry:
 
 ```
-$ docker build -t DOCKERHUB_USERNAME/hello .
-$ docker images
-$ docker tag IMAGE_ID DOCKERHUB_USERNAME/hello:latest
+$ docker build -t DOCKERHUB_USERNAME/hello:latest .
 $ docker push DOCKERHUB_USERNAME/hello
 ```
 


### PR DESCRIPTION
Had to chase this down.  Using original instructions:
docker push gherlein/hello:latest
The push refers to a repository [docker.io/gherlein/hello](len: 1)
Repository does not exist: gherlein/hello

Using changed instructions:
docker build -t gherlein/hello .
Sending build context to Docker daemon 4.389 MB
Step 1 : FROM scratch
 ---> 
Step 2 : ADD hello /
 ---> Using cache
 ---> 5202557bc674
Step 3 : CMD /hello
 ---> Using cache
 ---> 2f1d57e29917
Successfully built 2f1d57e29917

docker images
REPOSITORY          TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
gherlein/hello      latest              2f1d57e29917        19 minutes ago      4.383 MB

docker push gherlein/hello:latest
The push refers to a repository [docker.io/gherlein/hello](len: 1)
2f1d57e29917: Pushed 
5202557bc674: Pushed 
latest: digest: sha256:ac45fd7c1c7f28c880e0504c2fbca9dc4e7fe7f0fd7bd5d84e8fbbd57141f6c4 size: 2744
